### PR TITLE
Fix: merge() should not mutate other sketch's sparse data cursor

### DIFF
--- a/java/com/google/zetasketch/internal/hllplus/SparseRepresentation.java
+++ b/java/com/google/zetasketch/internal/hllplus/SparseRepresentation.java
@@ -22,6 +22,7 @@ import com.google.zetasketch.internal.DifferenceDecoder;
 import com.google.zetasketch.internal.DifferenceEncoder;
 import com.google.zetasketch.internal.GrowingByteSlice;
 import com.google.zetasketch.internal.MergedIntIterator;
+import com.google.zetasketch.internal.ByteSlice;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import it.unimi.dsi.fastutil.ints.IntHash.Strategy;
@@ -274,7 +275,7 @@ public class SparseRepresentation extends Representation {
   protected Representation merge(SparseRepresentation other) {
     // TODO: Add special case when 'this' is empty and 'other' has only encoded data.
     // In that case, we can just copy over the sparse data without needing to decode and dedupe.
-    return this.addSparseValues(other.encoding, other.sortedIterator());
+    return this.addSparseValues(other.encoding, other.sortedIteratorForMerge());
   }
 
   /**
@@ -389,11 +390,38 @@ public class SparseRepresentation extends Representation {
     return a;
   }
 
+  /**
+   * Returns an iterator over the sorted (but not de-duplicated) values of the difference encoded
+   * data and the temporary buffer, or {@code null} if both are empty.
+   * here the difference actual values inside the difference encoded data is copied and consumed
+   */
+  private IntIterator sortedIteratorForMerge() {
+    IntIterator a = copyAndReadDataIterator();
+    IntIterator b = bufferIterator();  // same question applies here — see below
+
+    if (a != null && b != null) {
+      return new MergedIntIterator(a, b);
+    }
+    if (b != null) {
+      return b;
+    }
+    return a;
+  }
+
   /** Returns an iterator over the difference encoded data, or {@code null} if it is empty. */
   @Nullable
   private IntIterator dataIterator() {
     if (state.hasSparseData()) {
       return new DifferenceDecoder(state.sparseData);
+    }
+    return null;
+  }
+
+  /** a read only copy of sparseData which will not modify the original ByteSlice instance.
+   * Used in merge on other object. **/
+  private IntIterator copyAndReadDataIterator() {
+    if (state.sparseData != null && state.hasSparseData()) {
+      return new DifferenceDecoder(ByteSlice.copyOnWrite(state.sparseData));
     }
     return null;
   }


### PR DESCRIPTION
Fixes the bug where merging two HLL++ sketches in sparse mode destructively advances the source sketch's `sparseData`/`buffer` position cursor, making the source sketch appear empty after the merge and returning incorrect estimates.

---

**Problem**

`SparseRepresentation.merge()` calls `other.sortedIterator()` on the source sketch, which internally calls `dataIterator()` and `bufferIterator()`. Both iterate using relative cursor reads (`getNextVarInt()`), advancing `position` to `limit` on the source's `ByteSlice`/`GrowingByteSlice`. After the merge, `hasSparseData()` returns `false` on the source and any subsequent `estimate()` or operation on it silently returns wrong results.

---

**Fix**

Introduced two new methods:
- `copyAndReadDataIterator()` wraps `state.sparseData` in a `ByteSlice.copyOnWrite()` snapshot before iterating
- `sortedIteratorForMerge()` uses the `copyAndReadDataIterator()` for getting the iterator

Introduced `sortedIteratorForMerge()` which uses these snapshot-based iterators instead of the originals. `merge()` now calls `other.sortedIteratorForMerge()` instead of `other.sortedIterator()`.

The existing `sortedIterator()`, `dataIterator()` and `bufferIterator()` are unchanged since their cursor-advancing behaviour is correct and expected in all non-merge call sites.

This fixes issue: [ISSUE-17](https://github.com/google/zetasketch/issues/17)